### PR TITLE
Ea 2604 solution original subtitles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <spring-boot.version>2.1.4.RELEASE</spring-boot.version>
-        <spring-hystrix.version>2.1.1.RELEASE</spring-hystrix.version>
         <jackson-core.version>2.9.4</jackson-core.version>
         <jsonpath.version>2.4.0</jsonpath.version>
         <mockito.version>2.15.0</mockito.version>
@@ -40,7 +39,6 @@
 
 <!--        tried updating, but too many $&%# dependency issues for now -->
         <!--		<spring-boot.version>2.4.4</spring-boot.version>-->
-        <!--		<spring-hystrix.version>2.2.7.RELEASE</spring-hystrix.version>-->
         <!--		<jackson.version>2.11.0</jackson.version>-->
         <!--		<jackson-core.version>2.12.3</jackson-core.version>-->
         <!--		<jsonpath.version>2.5.0</jsonpath.version>-->
@@ -89,16 +87,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
-            <version>${spring-hystrix.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-netflix-hystrix-dashboard</artifactId>
-            <version>${spring-hystrix.version}</version>
         </dependency>
 
         <!-- for retrieving record data -->

--- a/src/main/java/eu/europeana/iiif/ManifestApplication.java
+++ b/src/main/java/eu/europeana/iiif/ManifestApplication.java
@@ -9,10 +9,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -22,8 +19,6 @@ import java.util.Collections;
  * Created on 6-12-2017
  */
 @SpringBootApplication
-//@EnableHystrixDashboard
-//@EnableCircuitBreaker
 @PropertySource(value = "classpath:build.properties", ignoreResourceNotFound = true)
 public class ManifestApplication extends SpringBootServletInitializer {
 

--- a/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryCanvas.java
+++ b/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryCanvas.java
@@ -62,6 +62,9 @@ public class FulltextSummaryCanvas extends JsonLdIdType {
         return originalLanguage;
     }
 
+    /*
+     * Used by Jackson deserializing data from Fulltext API
+     */
     public void setOriginalLanguage(String originalLanguage) {
         this.originalLanguage = originalLanguage;
     }

--- a/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryCanvas.java
+++ b/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryCanvas.java
@@ -19,6 +19,8 @@ public class FulltextSummaryCanvas extends JsonLdIdType {
 
     private static final Pattern PAGENUMBERPATTERN = Pattern.compile("/canvas/(\\d+)$");
 
+    private String originalLanguage;
+
     @JsonProperty("annotations")
     private List<FulltextSummaryAnnoPage> annotations;
 
@@ -54,5 +56,21 @@ public class FulltextSummaryCanvas extends JsonLdIdType {
         } else {
             return "x";
         }
+    }
+
+    public String getOriginalLanguage() {
+        return originalLanguage;
+    }
+
+    public void setOriginalLanguage(String originalLanguage) {
+        this.originalLanguage = originalLanguage;
+    }
+
+    public List<String> getAnnoPageIDs(){
+        List<String> annoPageIDs  = new ArrayList<>();
+        for (FulltextSummaryAnnoPage sap : annotations) {
+            annoPageIDs.add(sap.getId());
+        }
+        return annoPageIDs;
     }
 }

--- a/src/main/java/eu/europeana/iiif/model/v2/AnnotationBody.java
+++ b/src/main/java/eu/europeana/iiif/model/v2/AnnotationBody.java
@@ -1,5 +1,6 @@
 package eu.europeana.iiif.model.v2;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
 
 /**
@@ -13,6 +14,9 @@ public class AnnotationBody extends JsonLdId {
 
     private String format;
     private Service service;
+
+    @JsonProperty("language")
+    private String originalLanguage;
 
     public AnnotationBody(String id) {
         super(id);
@@ -32,5 +36,13 @@ public class AnnotationBody extends JsonLdId {
 
     public void setService(Service service) {
         this.service = service;
+    }
+
+    public String getOriginalLanguage() {
+        return originalLanguage;
+    }
+
+    public void setOriginalLanguage(String originalLanguage) {
+        this.originalLanguage = originalLanguage;
     }
 }

--- a/src/main/java/eu/europeana/iiif/model/v3/AnnotationBody.java
+++ b/src/main/java/eu/europeana/iiif/model/v3/AnnotationBody.java
@@ -1,5 +1,7 @@
 package eu.europeana.iiif.model.v3;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * @author Patrick Ehlert
  * Created on 24-01-2018
@@ -10,6 +12,9 @@ public class AnnotationBody extends JsonLdIdType {
 
     private String format;
     private Service service;
+
+    @JsonProperty("language")
+    private String originalLanguage;
 
     public AnnotationBody(String id, String type) {
         super(id, type);
@@ -29,5 +34,13 @@ public class AnnotationBody extends JsonLdIdType {
 
     public void setService(Service service) {
         this.service = service;
+    }
+
+    public String getOriginalLanguage() {
+        return originalLanguage;
+    }
+
+    public void setOriginalLanguage(String originalLanguage) {
+        this.originalLanguage = originalLanguage;
     }
 }

--- a/src/main/java/eu/europeana/iiif/service/ManifestService.java
+++ b/src/main/java/eu/europeana/iiif/service/ManifestService.java
@@ -25,6 +25,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -239,11 +240,11 @@ public class ManifestService {
                     summary = getJsonMapper().readValue(EntityUtils.toString(entity), FulltextSummary.class);
                     EntityUtils.consume(entity); // make sure entity is consumed fully so connection can be reused
                 } else {
-                    LOG.warn("Request entity = null");
+                    LOG.warn("No response from Fulltext API received");
                 }
             }
         } catch (IOException e) {
-            LOG.error("Error checking if full text exists", e);
+            LOG.error("Error connecting to Fulltext API at {}", fullTextUrl, e);
             result = false;
         }
         if (result && null != summary) {

--- a/src/main/java/eu/europeana/iiif/service/ManifestService.java
+++ b/src/main/java/eu/europeana/iiif/service/ManifestService.java
@@ -12,11 +12,9 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 import eu.europeana.iiif.config.ManifestSettings;
 import eu.europeana.iiif.model.info.FulltextSummary;
-import eu.europeana.iiif.model.info.FulltextSummaryAnnoPage;
 import eu.europeana.iiif.model.info.FulltextSummaryCanvas;
 import eu.europeana.iiif.model.v2.ManifestV2;
 import eu.europeana.iiif.model.v2.Sequence;
-import eu.europeana.iiif.model.v3.Annotation;
 import eu.europeana.iiif.model.v3.AnnotationPage;
 import eu.europeana.iiif.model.v3.ManifestV3;
 import eu.europeana.iiif.service.exception.*;
@@ -230,7 +228,7 @@ public class ManifestService {
         try {
             try (CloseableHttpResponse response = gethttpClient.execute(new HttpGet(fullTextUrl))) {
                 int responseCode = response.getStatusLine().getStatusCode();
-                LOG.debug("Full-Text summary GET request: {}, status code = {}", fullTextUrl, responseCode);
+                LOG.error("Full-Text summary GET request: {}, status code = {}", fullTextUrl, responseCode);
                 if (responseCode == HttpStatus.SC_UNAUTHORIZED) {
                     throw new InvalidApiKeyException(APIKEY_NOT_VALID);
                 } else if (responseCode == HttpStatus.SC_NOT_FOUND) {

--- a/src/main/java/eu/europeana/iiif/service/ManifestService.java
+++ b/src/main/java/eu/europeana/iiif/service/ManifestService.java
@@ -25,7 +25,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;

--- a/src/test/java/eu/europeana/iiif/service/ManifestServiceTest.java
+++ b/src/test/java/eu/europeana/iiif/service/ManifestServiceTest.java
@@ -3,6 +3,7 @@ package eu.europeana.iiif.service;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import eu.europeana.iiif.ExampleData;
+import eu.europeana.iiif.model.info.FulltextSummaryCanvas;
 import eu.europeana.iiif.model.v2.ManifestV2;
 import eu.europeana.iiif.model.v3.ManifestV3;
 import eu.europeana.iiif.config.ManifestSettings;
@@ -221,11 +222,11 @@ public class ManifestServiceTest {
      */
     @Test
     public void testFullTextSummaryExists() throws IIIFException {
-        String                url    = ms.generateFullTextSummaryUrl(EXAMPLE_FULLTEXT_ID, getFullTextApiUrl());
-        Map<String, String[]> result = ms.getFullTextSummary(url);
+        String                             url    = ms.generateFullTextSummaryUrl(EXAMPLE_FULLTEXT_ID, getFullTextApiUrl());
+        Map<String, FulltextSummaryCanvas> result = ms.getFullTextSummary(url);
         Assert.assertEquals(1, result.keySet().size());
-        Assert.assertEquals(2, result.get("1").length);
-        Assert.assertEquals(EXAMPLE_FULLTEXT_SUMMARY_FRAGMENT, Arrays.stream(result.get("1")).toArray()[0]);
+        Assert.assertEquals(2, result.get("1").getAnnoPageIDs().size());
+        Assert.assertEquals(EXAMPLE_FULLTEXT_SUMMARY_FRAGMENT, Arrays.stream(result.get("1").getAnnoPageIDs().toArray(new String[0])).toArray()[0]);
     }
 
     /**
@@ -234,7 +235,7 @@ public class ManifestServiceTest {
     @Test
     public void testFullTextSummaryNotExists() throws IIIFException {
         String                url    = ms.generateFullTextSummaryUrl(TEST_BLA, getFullTextApiUrl());
-        Map<String, String[]> result = ms.getFullTextSummary(url);
+        Map<String, FulltextSummaryCanvas> result = ms.getFullTextSummary(url);
         assertNull(result);
     }
 
@@ -244,7 +245,7 @@ public class ManifestServiceTest {
     @Test
     public void testFullTextServerError() throws IIIFException {
         String url = ms.generateFullTextSummaryUrl(EXAMPLE_ERROR_ID, getFullTextApiUrl());
-        Map<String, String[]> result = ms.getFullTextSummary(url);
+        Map<String, FulltextSummaryCanvas> result = ms.getFullTextSummary(url);
         assertNull(result);
     }
 
@@ -254,7 +255,7 @@ public class ManifestServiceTest {
     @Test
     public void testFullTextTimeout() throws IIIFException {
         String url = ms.generateFullTextSummaryUrl(EXAMPLE_TIMEOUT_ID, getFullTextApiUrl());
-        Map<String, String[]> result = ms.getFullTextSummary(url);
+        Map<String, FulltextSummaryCanvas> result = ms.getFullTextSummary(url);
         assertNull(result);
     }
 

--- a/src/test/java/eu/europeana/iiif/service/ManifestServiceTest.java
+++ b/src/test/java/eu/europeana/iiif/service/ManifestServiceTest.java
@@ -1,7 +1,6 @@
 package eu.europeana.iiif.service;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.netflix.hystrix.exception.HystrixRuntimeException;
 import eu.europeana.iiif.ExampleData;
 import eu.europeana.iiif.model.info.FulltextSummaryCanvas;
 import eu.europeana.iiif.model.v2.ManifestV2;
@@ -17,7 +16,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -49,9 +47,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 @TestPropertySource(locations = "classpath:iiif-test.properties")
 @SpringBootTest(classes = {ManifestService.class, ManifestSettings.class, SpringContext.class})
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-// The following 2 annotations are needed to enable hystrix so we can test timeouts and fallbacks
-@EnableCircuitBreaker
-@EnableAspectJAutoProxy
 public class ManifestServiceTest {
 
     @Rule


### PR DESCRIPTION
This code change adds the the original language of the Fulltext (media) to: 

- the Annotation **Resource** where "motivation" = "sc:painting" (v2); 
- the Annotation **Body** where "motivation" = "painting" (v3)

For this to work, the Fulltext Summary JSON output needs to have the originalLanguage field added on the SummaryCanvas level. This functionality was added to the Fulltext API in [this PR](https://github.com/europeana/fulltext/pull/49)