### PR TITLE
Ea 3369 add textgranularity manifest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Send only unzipped war directory to Docker
+**
+!/target/manifest-api/
+**/*.user.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Builds a docker image from a locally built Maven war. Requires 'mvn package' to have been run beforehand
+FROM tomcat:9.0-jre11
+LABEL Author="Europeana Foundation <development@europeana.eu>"
+WORKDIR /usr/local/tomcat/webapps
+
+ENV ELASTIC_APM_VERSION 1.34.1
+ADD https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/$ELASTIC_APM_VERSION/elastic-apm-agent-$ELASTIC_APM_VERSION.jar /usr/local/elastic-apm-agent.jar
+
+# Copy unzipped directory so we can mount config files in Kubernetes pod
+COPY target/manifest-api/ ./ROOT/

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iiif-api-deployment
+spec:
+  # selector.matchLabels is provided via Kustomize
+  template:
+    spec:
+      containers:
+        - name: iiif-api
+          image: europeana/iiif-api
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /actuator/info
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /actuator/info
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: secret
+              mountPath: "/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/iiif.user.properties"
+              readOnly: true
+              subPath: iiif.user.properties
+      volumes:
+        - name: secret
+          secret:
+            secretName: iiif-api-secret

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - deployment.yaml
+
+commonLabels:
+  app: iiif-api
+
+# expects files to be in the same directory
+secretGenerator:
+  - name: iiif-api-secret
+    files:
+      - iiif.user.properties

--- a/k8s/overlays/cloud/deployment_patch.yaml.template
+++ b/k8s/overlays/cloud/deployment_patch.yaml.template
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iiif-api-deployment
+spec:
+  replicas: ${MIN_REPLICAS}
+  template:
+    metadata:
+      annotations:
+        fluentd/include: '${COLLECT_LOGS}'
+        fluentd/multiline: 'true'
+    spec:
+      containers:
+        - name: iiif-api
+          imagePullPolicy: Always
+          env:
+            - name: CATALINA_OPTS
+              value: "-javaagent:/usr/local/elastic-apm-agent.jar
+                      -Delastic.apm.application_packages=${ELASTIC_APP_PACKAGES}
+                      -Delastic.apm.server_urls=${ELASTIC_APM_SERVERS}
+                      -Delastic.apm.service_name=${APP_NAME}
+                      -Delastic.apm.environment=${K8S_NAMESPACE}"
+          resources:
+            requests:
+              memory: "${MEMORY_REQUEST}M"
+              cpu: "${CPU_REQUEST}m"
+            limits:
+              memory: "${MEMORY_LIMIT}M"
+              cpu: "${CPU_LIMIT}m"

--- a/k8s/overlays/cloud/hpa.yaml.template
+++ b/k8s/overlays/cloud/hpa.yaml.template
@@ -1,0 +1,21 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: iiif-api-hpa
+spec:
+  maxReplicas: ${MAX_REPLICAS}
+  minReplicas: ${MIN_REPLICAS}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: iiif-api-deployment
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 900
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/overlays/cloud/ingress.yaml.template
+++ b/k8s/overlays/cloud/ingress.yaml.template
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: iiif-api-ingress
+  annotations:
+    ${K8S_INGRESS_ANNOTATIONS}
+spec:
+  ingressClassName: public-iks-k8s-nginx
+  tls:
+    - hosts:
+        - ${K8S_HOSTNAME}
+      secretName: ${K8S_SECRETNAME}
+  rules:
+    - host: ${K8S_HOSTNAME}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: iiif-api-service
+                port:
+                  number: 80

--- a/k8s/overlays/cloud/kustomization.yaml
+++ b/k8s/overlays/cloud/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../../base
+  - service.yaml
+  - ingress.yaml
+  - hpa.yaml
+
+patchesStrategicMerge:
+  - deployment_patch.yaml
+
+commonLabels:
+  app: iiif-api

--- a/k8s/overlays/cloud/service.yaml
+++ b/k8s/overlays/cloud/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: iiif-api-service
+spec:
+  # selector provided via kustomize
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/k8s/overlays/dev/deployment_patch.yaml
+++ b/k8s/overlays/dev/deployment_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iiif-api-deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: iiif-api
+          # required to use local image
+          imagePullPolicy: Never

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - ../../base
+  - nodeport.yaml
+
+patchesStrategicMerge:
+  - deployment_patch.yaml
+
+commonLabels:
+  app: iiif-api

--- a/k8s/overlays/dev/nodeport.yaml
+++ b/k8s/overlays/dev/nodeport.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: iiif-api-nodeport
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      nodePort: 31000
+  # selector provided via kustomize

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>eu.europeana</groupId>
         <artifactId>europeana-parent-pom</artifactId>
-        <version>2.0</version>
+        <version>2.4</version>
     </parent>
 
     <groupId>eu.europeana.iiif</groupId>
@@ -13,8 +13,8 @@
     <version>0.8.3-SNAPSHOT</version>
     <packaging>war</packaging>
 
-    <name>Europeana IIIF Manifest API</name>
-    <description>Europeana IIIF Manifest API supporting IIIF v2 manifests</description>
+    <name>IIIF Manifest API</name>
+    <description>Europeana IIIF Manifest API supporting IIIF v2 and v3 manifests</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
+++ b/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
@@ -162,10 +162,10 @@ public class ManifestSettings {
     }
 
     /**
-     * @return Record API endpoint: record API Base URL + record API resource path + /
+     * @return Record API endpoint: record API Base URL + record API resource path
      */
     public String getRecordApiEndpoint() {
-        return getRecordApiBaseUrl() + getRecordApiPath() + "/";
+        return getRecordApiBaseUrl() + getRecordApiPath();
     }
 
     /**

--- a/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
+++ b/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
@@ -255,7 +255,7 @@ public class ManifestSettings {
      * @return URL built from Content search base URL, manifest API presentation path, Europeana ID and Fulltext search path
      */
     public String getContentSearchURL(String europeanaId){
-        return getContentSearchBaseUrl() + getManifestApiPresentationPath() + "/" + europeanaId + IIIFDefinitions.FULLTEXT_SEARCH_PATH;
+        return getContentSearchBaseUrl() + getManifestApiPresentationPath() + europeanaId + IIIFDefinitions.FULLTEXT_SEARCH_PATH;
     }
 
 

--- a/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
+++ b/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
@@ -28,8 +28,27 @@ public class ManifestSettings {
 
     private static final Logger LOG = LogManager.getLogger(ManifestSettings.class);
 
+    @Value("${manifest-api.baseurl}")
+    private String manifestApiBaseUrl;
+
+    @Value("${manifest-api.path}")
+    private String manifestApiPath;
+
+    @Value("${content-search-api.baseurl}")
+    private String contentSearchBaseUrl;
+
+    @Value("${content-search-api.path}")
+    private String contentSearchPath;
+
+    @Value("${fulltext-api.baseurl}")
+    private String fullTextApiBaseUrl;
+
+    @Value("${fulltext-api.path}")
+    private String fullTextApiPath;
+
     @Value("${record-api.baseurl}")
     private String recordApiBaseUrl;
+
     @Value("${record-api.path}")
     private String recordApiPath;
 
@@ -39,11 +58,34 @@ public class ManifestSettings {
     @Value("${thumbnail-api.path}")
     private String thumbnailApiPath;
 
-    @Value("${fulltext-api.baseurl}")
-    private String fullTextApiBaseUrl;
-
     @Value("${suppress-parse-exception}")
     private final Boolean suppressParseException = Boolean.FALSE; // default value if we run this outside of Spring (i.e. JUnit)
+
+
+
+    public String getManifestApiBaseUrl() {
+        return manifestApiBaseUrl;
+    }
+
+    public String getManifestApiPath() {
+        return manifestApiPath;
+    }
+
+
+    public String getContentSearchBaseUrl() {
+        return contentSearchBaseUrl;
+    }
+
+    public String getContentSearchPath() {
+        return contentSearchPath;
+    }
+
+    /**
+     * @return base url from where we can do a HEAD request to check if a full-text is available
+     */
+    public String getFullTextApiBaseUrl() {
+        return fullTextApiBaseUrl;
+    }
 
     /**
      * @return base url from where we should retrieve record json data
@@ -64,13 +106,6 @@ public class ManifestSettings {
      */
     public String getThumbnailApiUrl() {
         return thumbnailApiBaseUrl + thumbnailApiPath;
-    }
-
-    /**
-     * @return base url from where we can do a HEAD request to check if a full-text is available
-     */
-    public String getFullTextApiBaseUrl() {
-        return fullTextApiBaseUrl;
     }
 
     /**

--- a/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
+++ b/src/main/java/eu/europeana/iiif/config/ManifestSettings.java
@@ -1,7 +1,11 @@
 package eu.europeana.iiif.config;
 
+import eu.europeana.iiif.IIIFDefinitions;
+import eu.europeana.iiif.model.ManifestDefinitions;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -31,20 +35,17 @@ public class ManifestSettings {
     @Value("${manifest-api.baseurl}")
     private String manifestApiBaseUrl;
 
-    @Value("${manifest-api.path}")
-    private String manifestApiPath;
+    @Value("${manifest-api.presentation.path}")
+    private String manifestApiPresentationPath;
+
+    @Value("${manifest-api.id.placeholder}")
+    private String manifestApiIdPlaceholder;
 
     @Value("${content-search-api.baseurl}")
     private String contentSearchBaseUrl;
 
-    @Value("${content-search-api.path}")
-    private String contentSearchPath;
-
     @Value("${fulltext-api.baseurl}")
     private String fullTextApiBaseUrl;
-
-    @Value("${fulltext-api.path}")
-    private String fullTextApiPath;
 
     @Value("${record-api.baseurl}")
     private String recordApiBaseUrl;
@@ -62,43 +63,109 @@ public class ManifestSettings {
     private final Boolean suppressParseException = Boolean.FALSE; // default value if we run this outside of Spring (i.e. JUnit)
 
 
-
+    /**
+     * Get the value for Manifest API base URL
+     * @return if defined, returns the value from iiif.properties
+     * If not, returns the value for IIIF Europeana Base URL from IIIFDefinitions
+     * if that's not found, returns the value for fulltext Base URL defined in iiif.properties
+     */
     public String getManifestApiBaseUrl() {
-        return manifestApiBaseUrl;
-    }
-
-    public String getManifestApiPath() {
-        return manifestApiPath;
-    }
-
-
-    public String getContentSearchBaseUrl() {
-        return contentSearchBaseUrl;
-    }
-
-    public String getContentSearchPath() {
-        return contentSearchPath;
+        if (StringUtils.isNotBlank(manifestApiBaseUrl)){
+            LOG.debug("Using Manifest base URL from iiif.properties: {}", manifestApiBaseUrl);
+            return manifestApiBaseUrl;
+        } else if (StringUtils.isNotBlank(IIIFDefinitions.IIIF_EUROPENA_BASE_URL)){
+            LOG.debug("Using IIIFDefinitions value forManifest base URL: {}", IIIFDefinitions.IIIF_EUROPENA_BASE_URL);
+            return IIIFDefinitions.IIIF_EUROPENA_BASE_URL;
+        } else if (StringUtils.isNotBlank(fullTextApiBaseUrl)){
+            LOG.warn("Falling back to Fulltext API base URL {} in iiif.properties for Manifest API base URL", fullTextApiBaseUrl);
+            return fullTextApiBaseUrl;
+        } else {
+            LOG.error("No value found for Manifest base URL, Fulltext base URL or IIIFDefinitions.IIIF_EUROPENA_BASE_URL!");
+            return null;
+        }
     }
 
     /**
-     * @return base url from where we can do a HEAD request to check if a full-text is available
+     * Get the value for Manifest API presentation path
+     * @return the value from iiif.properties
+     * If not defined, use the value from IIIFDefinitions
+     */
+    public String getManifestApiPresentationPath() {
+        if (StringUtils.isNotBlank(manifestApiPresentationPath)){
+            LOG.debug("Using Presentation path found in iiif.properties: {}", manifestApiPresentationPath);
+            return manifestApiPresentationPath;
+        } else if (StringUtils.isNotBlank(IIIFDefinitions.PRESENTATION_PATH)){
+            LOG.debug("Using Presentation path from IIIFDefinitions: {}", IIIFDefinitions.PRESENTATION_PATH);
+            return IIIFDefinitions.PRESENTATION_PATH;
+        } else {
+            LOG.error("No value for presentation path found in iiif.properties or IIIFDefinitions!");
+            return null;
+        }
+    }
+
+    /**
+     * Get the value for ID PLACEHOLDER
+     * @return the value from iiif.properties
+     * If not defined, return the hard-coded value in ManifestDefinitions
+     */
+    public String getManifestApiIdPlaceholder() {
+        if (StringUtils.isNotBlank(manifestApiIdPlaceholder)){
+            LOG.debug("Using ID PLACEHOLDER from iiif.properties: {}", manifestApiIdPlaceholder);
+            return manifestApiIdPlaceholder;
+        } else if (StringUtils.isNotBlank(ManifestDefinitions.ID_PLACEHOLDER)){
+            LOG.debug("Using ID PLACEHOLDER hard-coded in ManifestDefinitions: {}", ManifestDefinitions.ID_PLACEHOLDER);
+            return IIIFDefinitions.PRESENTATION_PATH;
+        } else {
+            LOG.error("No value found for ID_PLACEHOLDER!");
+            return null;
+        }
+    }
+
+    /**
+     * Get the value for Content Search Base URL
+     * @return the value from iiif.properties
+     * If not defined, return the Fulltext Base URL from iiif.properties
+     * TODO check if this is the right order, or if we could also fallback to Manifest API Base URL?
+     */
+    public String getContentSearchBaseUrl() {
+        if (StringUtils.isNotBlank(contentSearchBaseUrl)){
+            LOG.debug("Using Content Search Base URL from iiif.properties: {}", contentSearchBaseUrl);
+            return contentSearchBaseUrl;
+        } else if (StringUtils.isNotBlank(fullTextApiBaseUrl)){
+            LOG.debug("Using Fulltext Base URL for Context Search Base URL: {}", fullTextApiBaseUrl);
+            return fullTextApiBaseUrl;
+        } else {
+            LOG.error("No value found for Content Search Base URL!");
+            return null;
+        }
+    }
+
+    /**
+     * @return Fulltext Base URL defined in iiif.properties from where we can do a HEAD request to check if a full-text is available
      */
     public String getFullTextApiBaseUrl() {
         return fullTextApiBaseUrl;
     }
 
     /**
-     * @return base url from where we should retrieve record json data
+     * @return Record API Base URL from where we should retrieve record json data
      */
     public String getRecordApiBaseUrl() {
         return recordApiBaseUrl;
     }
 
     /**
-     * @return FulltextSummary resource path (should be appended to the record API base url)
+     * @return Record API resource path (should be appended to the record API base url)
      */
     public String getRecordApiPath() {
         return recordApiPath;
+    }
+
+    /**
+     * @return Record API endpoint: record API Base URL + record API resource path + /
+     */
+    public String getRecordApiEndpoint() {
+        return getRecordApiBaseUrl() + getRecordApiPath() + "/";
     }
 
     /**
@@ -115,6 +182,82 @@ public class ManifestSettings {
     public Boolean getSuppressParseException() {
         return suppressParseException;
     }
+
+    /**
+     * Base URL used for generation the various types of IDs
+     */
+    public String getIIIFPresentationBaseUrl(){
+        return getManifestApiBaseUrl() + getManifestApiPresentationPath() + getManifestApiIdPlaceholder();
+    }
+
+    /**
+     * Url of all manifest IDs but with placeholder for the actual dataset and record ID
+     */
+    public String getManifestIdTemplate() {
+        return getIIIFPresentationBaseUrl() + "/manifest";
+    }
+
+    /**
+     * Url of a sequence IDs but with placeholder for the actual dataset and record ID. Note that there the order number
+     * is not included here (so first sequence should be /sequence/s1)
+     */
+    public String getSequenceIDTemplate() {
+        return getIIIFPresentationBaseUrl() + "/sequence/s";
+    }
+
+    /**
+     * Url for canvas IDs but with placeholder for the actual dataset and record ID Note that there the order number is
+     * not included here (so first canvas should be /canvas/p1)
+     */
+    public String getCanvasIDTemplate(){
+        return getIIIFPresentationBaseUrl() + "/canvas/p";
+    }
+
+    /**
+     * Create the IIIF manifest ID
+     *
+     * @param europeanaId consisting of dataset ID and record ID separated by a slash (string should have a leading
+     *                    slash and not trailing slash)
+     * @return string containing the IIIF manifest ID
+     */
+    public String getManifestId(String europeanaId) {
+        return getManifestIdTemplate().replace(getManifestApiIdPlaceholder(), europeanaId);
+    }
+
+    /**
+     * Create a canvas ID
+     *
+     * @param europeanaId consisting of dataset ID and record ID separated by a slash (string should have a leading
+     *                    slash and not trailing slash)
+     * @param order       number
+     * @return String containing the canvas ID
+     */
+    public String getCanvasId(String europeanaId, int order) {
+        return getCanvasIDTemplate().replace(getManifestApiIdPlaceholder(), europeanaId).concat(
+            Integer.toString(order));
+    }
+
+    /**
+     * Create a dataset ID (datasets information are part of the manifest)
+     *
+     * @param europeanaId consisting of dataset ID and record ID separated by a slash (string should have a leading
+     *                    slash and not trailing slash)
+     * @return string containing the dataset ID consisting of a base url, Europeana ID and postfix (rdf/xml, json or
+     * json-ld)
+     */
+    public String getDatasetId(String europeanaId, String postFix) {
+        return getRecordApiEndpoint() + europeanaId + postFix;
+    }
+
+    /**
+     * Get the Content Search URL used in the Manifest Service Description
+     * @param europeanaId
+     * @return URL built from Content search base URL, manifest API presentation path, Europeana ID and Fulltext search path
+     */
+    public String getContentSearchURL(String europeanaId){
+        return getContentSearchBaseUrl() + getManifestApiPresentationPath() + "/" + europeanaId + IIIFDefinitions.FULLTEXT_SEARCH_PATH;
+    }
+
 
     /**
      * Note: this does not work when running the exploded build from the IDE because the values in the build.properties
@@ -139,9 +282,22 @@ public class ManifestSettings {
     @PostConstruct
     private void logImportantSettings() {
         LOG.info("Manifest settings:");
-        LOG.info("  Record API Url = {}{} ", this.getRecordApiBaseUrl(), this.getRecordApiPath());
+        if (StringUtils.isNotBlank(manifestApiBaseUrl)){
+            LOG.info("  Manifest API Base Url set to {} ", manifestApiBaseUrl);
+        }
+        if (StringUtils.isNotBlank(manifestApiPresentationPath)){
+            LOG.info("  Manifest API presentation path set to {} ", manifestApiPresentationPath);
+        }
+        if (StringUtils.isNotBlank(manifestApiIdPlaceholder)){
+            LOG.info("  Manifest API ID placeholder set to {} ", manifestApiIdPlaceholder);
+        }
+        if (StringUtils.isNotBlank(contentSearchBaseUrl)){
+            LOG.info(" Content Search API base URL set to {} ", contentSearchBaseUrl);
+        }
+        LOG.info("  Record API endpoint = {} ", getRecordApiEndpoint());
         LOG.info("  Thumbnail API Url = {} ", this.getThumbnailApiUrl());
         LOG.info("  Full-Text Summary Url = {}{} ", this.getFullTextApiBaseUrl(), getFulltextSummaryPath("/<collectionId>/<itemId>"));
         LOG.info("  Suppress parse exceptions = {}", this.getSuppressParseException());
     }
+
 }

--- a/src/main/java/eu/europeana/iiif/model/ManifestDefinitions.java
+++ b/src/main/java/eu/europeana/iiif/model/ManifestDefinitions.java
@@ -16,34 +16,6 @@ public final class ManifestDefinitions {
     public static final String ID_PLACEHOLDER = "{DATASET_ID}/{RECORD_ID}";
 
     /**
-     * Base URL used for generation the various types of IDs
-     */
-    public static final String IIIF_PRESENTATION_BASE_URL =
-        IIIFDefinitions.IIIF_EUROPENA_BASE_URL + IIIFDefinitions.PRESENTATION_PATH + ID_PLACEHOLDER;
-
-    /**
-     * Url of all manifest IDs but with placeholder for the actual dataset and record ID
-     */
-    public static final String MANIFEST_ID = IIIF_PRESENTATION_BASE_URL + "/manifest";
-
-    /**
-     * Url of a sequence IDs but with placeholder for the actual dataset and record ID. Note that there the order number
-     * is not included here (so first sequence should be /sequence/s1)
-     */
-    public static final String SEQUENCE_ID = IIIF_PRESENTATION_BASE_URL + "/sequence/s";
-
-    /**
-     * Url for canvas IDs but with placeholder for the actual dataset and record ID Note that there the order number is
-     * not included here (so first canvas should be /canvas/p1)
-     */
-    public static final String CANVAS_ID = IIIF_PRESENTATION_BASE_URL + "/canvas/p";
-
-    /**
-     * Base url of a dataset ID (seeAlso part of manifest)
-     */
-    public static final String DATASET_ID_BASE_URL = "https://www.europeana.eu/api/v2/record";
-
-    /**
      * Media type for rdf
      */
     public static final String MEDIA_TYPE_RDF = "application/rdf+xml";
@@ -93,46 +65,6 @@ public final class ManifestDefinitions {
     public static String getFulltextSummaryPath(String europeanaId) {
         return IIIFDefinitions.PRESENTATION_PATH + europeanaId + IIIFDefinitions.FULLTEXT_SUMMARY_PATH +
                "/"; // for now trailing slash is needed
-    }
-
-    public static String getFulltextSearchPath(String europeanaId) {
-        return IIIFDefinitions.PRESENTATION_PATH + europeanaId + IIIFDefinitions.FULLTEXT_SEARCH_PATH;
-    }
-
-    /**
-     * Create the IIIF manifest ID
-     *
-     * @param europeanaId consisting of dataset ID and record ID separated by a slash (string should have a leading
-     *                    slash and not trailing slash)
-     * @return string containing the IIIF manifest ID
-     */
-    public static String getManifestId(String europeanaId) {
-        return ManifestDefinitions.MANIFEST_ID.replace(ManifestDefinitions.ID_PLACEHOLDER, europeanaId);
-    }
-
-    /**
-     * Create a canvas ID
-     *
-     * @param europeanaId consisting of dataset ID and record ID separated by a slash (string should have a leading
-     *                    slash and not trailing slash)
-     * @param order       number
-     * @return String containing the canvas ID
-     */
-    public static String getCanvasId(String europeanaId, int order) {
-        return ManifestDefinitions.CANVAS_ID.replace(ManifestDefinitions.ID_PLACEHOLDER, europeanaId).concat(
-            Integer.toString(order));
-    }
-
-    /**
-     * Create a dataset ID (datasets information are part of the manifest)
-     *
-     * @param europeanaId consisting of dataset ID and record ID separated by a slash (string should have a leading
-     *                    slash and not trailing slash)
-     * @return string containing the dataset ID consisting of a base url, Europeana ID and postfix (rdf/xml, json or
-     * json-ld)
-     */
-    public static String getDatasetId(String europeanaId, String postFix) {
-        return ManifestDefinitions.DATASET_ID_BASE_URL + europeanaId + postFix;
     }
 
 }

--- a/src/main/java/eu/europeana/iiif/model/info/FulltextSummary.java
+++ b/src/main/java/eu/europeana/iiif/model/info/FulltextSummary.java
@@ -1,6 +1,11 @@
 package eu.europeana.iiif.model.info;
 
+import static eu.europeana.iiif.IIIFDefinitions.MEDIA_TYPE_IIIF_V3;
+import static eu.europeana.iiif.IIIFDefinitions.MEDIA_TYPE_W3ORG_JSONLD;
+//import static eu.europeana.iiif.IIIFDefinitions.TEXT_GRANULARITY_CONTEXT;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import eu.europeana.iiif.IIIFDefinitions;
 
@@ -11,11 +16,16 @@ import java.util.List;
 /**
  * Created by luthien on 07/04/2021.
  */
+@JsonPropertyOrder({"@context", "textGranularity", "items"})
 public class FulltextSummary implements Serializable {
     private static final long serialVersionUID = -8052995235828716772L;
 
     @JsonProperty("@context")
-    private final String[] context = new String[]{IIIFDefinitions.MEDIA_TYPE_W3ORG_JSONLD, IIIFDefinitions.MEDIA_TYPE_IIIF_V3};
+    private final String[] context = new String[]{MEDIA_TYPE_W3ORG_JSONLD, MEDIA_TYPE_IIIF_V3};
+    // switch when available in this version
+//    private final String[] context = new String[]{MEDIA_TYPE_W3ORG_JSONLD, IIIFDefinitions.TEXT_GRANULARITY_CONTEXT, MEDIA_TYPE_IIIF_V3};
+
+    private String[] textGranularity;
 
     private String              dataSetId;
     private String              localId;
@@ -36,6 +46,14 @@ public class FulltextSummary implements Serializable {
         this.dataSetId = dataSetId;
         this.localId = localId;
         canvases = new ArrayList<>();
+    }
+
+    public String[] getTextGranularity() {
+        return textGranularity;
+    }
+
+    public void setTextGranularity(String[] textGranularity) {
+        this.textGranularity = textGranularity;
     }
 
     /**

--- a/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryAnnoPage.java
+++ b/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryAnnoPage.java
@@ -49,6 +49,14 @@ public class FulltextSummaryAnnoPage extends JsonLdIdType {
         this.language = language;
     }
 
+    public String[] getTextGranularity() {
+        return textGranularity;
+    }
+
+    public void setTextGranularity(String[] textGranularity) {
+        this.textGranularity = textGranularity;
+    }
+
     public String getSource() {
         return source;
     }

--- a/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryAnnoPage.java
+++ b/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryAnnoPage.java
@@ -16,6 +16,8 @@ public class FulltextSummaryAnnoPage extends JsonLdIdType {
     @JsonProperty("language")
     private String language;
 
+    private String[] textGranularity;
+
     @JsonIgnore
     private boolean orig;
 

--- a/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryCanvas.java
+++ b/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryCanvas.java
@@ -22,7 +22,7 @@ public class FulltextSummaryCanvas extends JsonLdIdType {
     private String originalLanguage;
 
     @JsonProperty("annotations")
-    private List<FulltextSummaryAnnoPage> annotations;
+    private List<FulltextSummaryAnnoPage> ftSummaryAnnoPages;
 
     public FulltextSummaryCanvas(){}
 
@@ -34,19 +34,19 @@ public class FulltextSummaryCanvas extends JsonLdIdType {
      */
     public FulltextSummaryCanvas(String id) {
         super(id, INFO_CANVAS_TYPE);
-        annotations = new ArrayList<>();
+        ftSummaryAnnoPages = new ArrayList<>();
     }
 
     /**
      * Adds an annotation - actually: an FulltextSummaryAnnoPage (AnnoPage for a specific language) to the FulltextSummaryCanvas
-     * @param alPage FulltextSummaryAnnoPage object to be added to the annotations List
+     * @param ftSummaryAnnoPage FulltextSummaryAnnoPage object to be added to the annotations List
      */
-    public void addAnnotation(FulltextSummaryAnnoPage alPage){
-        annotations.add(alPage);
+    public void addFTSummaryAnnoPage(FulltextSummaryAnnoPage ftSummaryAnnoPage){
+        ftSummaryAnnoPages.add(ftSummaryAnnoPage);
     }
 
-    public List<FulltextSummaryAnnoPage> getAnnotations() {
-        return new ArrayList<>(annotations);
+    public List<FulltextSummaryAnnoPage> getFTSummaryAnnoPages() {
+        return new ArrayList<>(ftSummaryAnnoPages);
     }
 
     /**
@@ -79,7 +79,7 @@ public class FulltextSummaryCanvas extends JsonLdIdType {
 
     public List<String> getAnnoPageIDs(){
         List<String> annoPageIDs  = new ArrayList<>();
-        for (FulltextSummaryAnnoPage sap : annotations) {
+        for (FulltextSummaryAnnoPage sap : ftSummaryAnnoPages) {
             annoPageIDs.add(sap.getId());
         }
         return annoPageIDs;
@@ -87,7 +87,7 @@ public class FulltextSummaryCanvas extends JsonLdIdType {
 
     public Map<String, String> getAnnoPageIDLang(){
         Map<String, String> annoPageLangs  = new HashMap<>();
-        for (FulltextSummaryAnnoPage sap : annotations) {
+        for (FulltextSummaryAnnoPage sap : ftSummaryAnnoPages) {
             annoPageLangs.put(sap.getId(), sap.getLanguage());
         }
         return annoPageLangs;

--- a/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryManifest.java
+++ b/src/main/java/eu/europeana/iiif/model/info/FulltextSummaryManifest.java
@@ -7,7 +7,6 @@ import static eu.europeana.iiif.IIIFDefinitions.MEDIA_TYPE_W3ORG_JSONLD;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
-import eu.europeana.iiif.IIIFDefinitions;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ import java.util.List;
  * Created by luthien on 07/04/2021.
  */
 @JsonPropertyOrder({"@context", "textGranularity", "items"})
-public class FulltextSummary implements Serializable {
+public class FulltextSummaryManifest implements Serializable {
     private static final long serialVersionUID = -8052995235828716772L;
 
     @JsonProperty("@context")
@@ -25,35 +24,25 @@ public class FulltextSummary implements Serializable {
     // switch when available in this version
 //    private final String[] context = new String[]{MEDIA_TYPE_W3ORG_JSONLD, IIIFDefinitions.TEXT_GRANULARITY_CONTEXT, MEDIA_TYPE_IIIF_V3};
 
-    private String[] textGranularity;
-
     private String              dataSetId;
     private String              localId;
 
     @JsonProperty("items")
     private List<FulltextSummaryCanvas> canvases;
 
-    public FulltextSummary(){}
+    public FulltextSummaryManifest() {}
 
     /**
      * This is a container object to group "fake" FulltextSummaryCanvas objects containing original and translated AnnoPages
      * for a given Fulltext record / object
      *
-     * @param dataSetId String containing the dataset of this Fulltext FulltextSummary
-     * @param localId   String containing the localId of this Fulltext FulltextSummary
+     * @param dataSetId String containing the dataset of this Fulltext FulltextSummaryManifest
+     * @param localId   String containing the localId of this Fulltext FulltextSummaryManifest
      */
-    public FulltextSummary(String dataSetId, String localId){
+    public FulltextSummaryManifest(String dataSetId, String localId){
         this.dataSetId = dataSetId;
         this.localId = localId;
         canvases = new ArrayList<>();
-    }
-
-    public String[] getTextGranularity() {
-        return textGranularity;
-    }
-
-    public void setTextGranularity(String[] textGranularity) {
-        this.textGranularity = textGranularity;
     }
 
     /**

--- a/src/main/java/eu/europeana/iiif/model/v3/AnnotationPage.java
+++ b/src/main/java/eu/europeana/iiif/model/v3/AnnotationPage.java
@@ -9,7 +9,11 @@ public class AnnotationPage extends JsonLdIdType {
     private static final long serialVersionUID = -259542823420543924L;
 
     private Annotation[] items;
+
     private String language;
+
+    private String[] textGranularity;
+
     private String source;
 
     public AnnotationPage(String id) {
@@ -28,8 +32,24 @@ public class AnnotationPage extends JsonLdIdType {
         this.source = source;
     }
 
+    // Used for creating Annotationpages with FullText summary "annotations" (actually, FTAnnoPages)
+    public AnnotationPage(String id, String language, String[] textGranularity, String source) {
+        super(id, "AnnotationPage");
+        this.language = language;
+        this.textGranularity = textGranularity;
+        this.source = source;
+    }
+
     public String getLanguage() {
         return language;
+    }
+
+    public String[] getTextGranularity() {
+        return textGranularity;
+    }
+
+    public void setTextGranularity(String[] textGranularity) {
+        this.textGranularity = textGranularity;
     }
 
     public Annotation[] getItems() {

--- a/src/main/java/eu/europeana/iiif/model/v3/Canvas.java
+++ b/src/main/java/eu/europeana/iiif/model/v3/Canvas.java
@@ -1,6 +1,7 @@
 package eu.europeana.iiif.model.v3;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author Patrick Ehlert
@@ -22,8 +23,10 @@ public class Canvas extends JsonLdIdType {
     private RequiredStatementMap requiredStatement;; // attribution
     private Rights rights;
     private AnnotationPage[] items;
-    private AnnotationPage[] annotations; // full text identifiers
-    private Image[] thumbnail;     // EA-3325
+
+    @JsonProperty("annotations")
+    private AnnotationPage[] ftSummaryAnnoPages; // full text identifiers
+    private Image[]          thumbnail;     // EA-3325
 
     /**
      * Create a new canvas object
@@ -122,12 +125,12 @@ public class Canvas extends JsonLdIdType {
      * If fulltext is available they this will contain AnnotationPages with only the full text identifier
      * @return array of {@link AnnotationPage} with full text identifiers (if fulltext is available)
      */
-    public AnnotationPage[] getAnnotations() {
-        return annotations;
+    public AnnotationPage[] getFtSummaryAnnoPages() {
+        return ftSummaryAnnoPages;
     }
 
-    public void setAnnotations(AnnotationPage[] annotations) {
-        this.annotations = annotations;
+    public void setFtSummaryAnnoPages(AnnotationPage[] ftSummaryAnnoPages) {
+        this.ftSummaryAnnoPages = ftSummaryAnnoPages;
     }
 
     public Image[] getThumbnail() {

--- a/src/main/java/eu/europeana/iiif/model/v3/Canvas.java
+++ b/src/main/java/eu/europeana/iiif/model/v3/Canvas.java
@@ -17,7 +17,9 @@ public class Canvas extends JsonLdIdType {
     private Integer height;
     private Integer width;
     private Double duration;
-    private LanguageMap requiredStatement; // attribution
+//    private LanguageMap requiredStatement; // attribution
+    // EA-3324
+    private RequiredStatementMap requiredStatement;; // attribution
     private Rights rights;
     private AnnotationPage[] items;
     private AnnotationPage[] annotations; // full text identifiers
@@ -83,11 +85,12 @@ public class Canvas extends JsonLdIdType {
         this.duration = duration;
     }
 
-    public LanguageMap getRequiredStatement() {
+    // EA-3324 changed type of RequiredStatement from LanguageMap to RequiredStatementMap
+    public RequiredStatementMap getRequiredStatement() {
         return requiredStatement;
     }
 
-    public void setRequiredStatement(LanguageMap requiredStatement) {
+    public void setRequiredStatement(RequiredStatementMap requiredStatement) {
         this.requiredStatement = requiredStatement;
     }
 

--- a/src/main/java/eu/europeana/iiif/service/EdmManifestMappingV2.java
+++ b/src/main/java/eu/europeana/iiif/service/EdmManifestMappingV2.java
@@ -54,7 +54,6 @@ public final class EdmManifestMappingV2 {
         THUMBNAIL_API_URL = settings.getThumbnailApiUrl();
         String europeanaId = EdmManifestUtils.getEuropeanaId(jsonDoc);
         String isShownBy = EdmManifestUtils.getValueFromDataProviderAggregation(jsonDoc, europeanaId, "edmIsShownBy");
-//        ManifestV2 manifest = new ManifestV2(europeanaId, ManifestDefinitions.getManifestId(europeanaId), isShownBy);
         ManifestV2 manifest = new ManifestV2(europeanaId, settings.getManifestId(europeanaId), isShownBy);
         manifest.setService(getServiceDescriptionV2(settings, europeanaId));
         // EA-3325

--- a/src/main/java/eu/europeana/iiif/service/EdmManifestMappingV2.java
+++ b/src/main/java/eu/europeana/iiif/service/EdmManifestMappingV2.java
@@ -50,12 +50,13 @@ public final class EdmManifestMappingV2 {
      * @param jsonDoc parsed json document
      * @return IIIF Manifest v2 object
      */
-    static ManifestV2 getManifestV2(ManifestSettings ms, Object jsonDoc) {
-        THUMBNAIL_API_URL = ms.getThumbnailApiUrl();
+    static ManifestV2 getManifestV2(ManifestSettings settings, Object jsonDoc) {
+        THUMBNAIL_API_URL = settings.getThumbnailApiUrl();
         String europeanaId = EdmManifestUtils.getEuropeanaId(jsonDoc);
         String isShownBy = EdmManifestUtils.getValueFromDataProviderAggregation(jsonDoc, europeanaId, "edmIsShownBy");
-        ManifestV2 manifest = new ManifestV2(europeanaId, ManifestDefinitions.getManifestId(europeanaId), isShownBy);
-        manifest.setService(getServiceDescriptionV2(ms.getFullTextApiBaseUrl(), europeanaId));
+//        ManifestV2 manifest = new ManifestV2(europeanaId, ManifestDefinitions.getManifestId(europeanaId), isShownBy);
+        ManifestV2 manifest = new ManifestV2(europeanaId, settings.getManifestId(europeanaId), isShownBy);
+        manifest.setService(getServiceDescriptionV2(settings, europeanaId));
         // EA-3325
 //        manifest.setWithin(getWithinV2(jsonDoc));
         manifest.setLabel(getLabelsV2(jsonDoc));
@@ -65,8 +66,8 @@ public final class EdmManifestMappingV2 {
         manifest.setNavDate(EdmManifestUtils.getNavDate(europeanaId, jsonDoc));
         manifest.setAttribution(getAttributionV2(europeanaId, isShownBy, jsonDoc));
         manifest.setLicense(getLicense(europeanaId, jsonDoc));
-        manifest.setSeeAlso(getDataSetsV2(europeanaId));
-        manifest.setSequences(getSequencesV2(europeanaId, isShownBy, jsonDoc));
+        manifest.setSeeAlso(getDataSetsV2(settings, europeanaId));
+        manifest.setSequences(getSequencesV2(settings, europeanaId, isShownBy, jsonDoc));
         if (manifest.getSequences() != null) {
             manifest.setStartCanvasPageNr(getStartCanvasV2(manifest.getSequences()[0].getCanvases(), isShownBy));
         }
@@ -76,8 +77,8 @@ public final class EdmManifestMappingV2 {
     /**
      * Generates a serviceV2 description for the manifest
      */
-    private static eu.europeana.iiif.model.v2.Service getServiceDescriptionV2(String fulltextBaseUrl, String europeanaId) {
-        return new eu.europeana.iiif.model.v2.Service(EdmManifestUtils.getFullTextSearchUrl(fulltextBaseUrl, europeanaId),
+    private static eu.europeana.iiif.model.v2.Service getServiceDescriptionV2(ManifestSettings settings, String europeanaId) {
+        return new eu.europeana.iiif.model.v2.Service(settings.getContentSearchURL(europeanaId),
                                                       ManifestDefinitions.SEARCH_CONTEXT_VALUE,
                                                       ManifestDefinitions.SEARCH_PROFILE_VALUE);
     }
@@ -229,13 +230,13 @@ public final class EdmManifestMappingV2 {
      * @param europeanaId consisting of dataset ID and record ID separated by a slash (string should have a leading slash and not trailing slash)
      * @return array of 3 datasets
      */
-    static eu.europeana.iiif.model.v2.DataSet[] getDataSetsV2(String europeanaId) {
+    static eu.europeana.iiif.model.v2.DataSet[] getDataSetsV2(ManifestSettings settings, String europeanaId) {
         eu.europeana.iiif.model.v2.DataSet[] result = new eu.europeana.iiif.model.v2.DataSet[3];
-        result[0] = new eu.europeana.iiif.model.v2.DataSet(ManifestDefinitions.getDatasetId(europeanaId, ".json-ld"),
+        result[0] = new eu.europeana.iiif.model.v2.DataSet(settings.getDatasetId(europeanaId, ".json-ld"),
                 AcceptUtils.MEDIA_TYPE_JSONLD);
-        result[1] = new eu.europeana.iiif.model.v2.DataSet(ManifestDefinitions.getDatasetId(europeanaId, ".json"),
+        result[1] = new eu.europeana.iiif.model.v2.DataSet(settings.getDatasetId(europeanaId, ".json"),
                 org.springframework.http.MediaType.APPLICATION_JSON_VALUE);
-        result[2] = new eu.europeana.iiif.model.v2.DataSet(ManifestDefinitions.getDatasetId(europeanaId, ".rdf"),
+        result[2] = new eu.europeana.iiif.model.v2.DataSet(settings.getDatasetId(europeanaId, ".rdf"),
                 ManifestDefinitions.MEDIA_TYPE_RDF);
         return result;
     }
@@ -246,7 +247,7 @@ public final class EdmManifestMappingV2 {
      * @param jsonDoc parsed json document
      * @return
      */
-    static eu.europeana.iiif.model.v2.Sequence[] getSequencesV2(String europeanaId, String isShownBy, Object jsonDoc) {
+    static eu.europeana.iiif.model.v2.Sequence[] getSequencesV2(ManifestSettings settings, String europeanaId, String isShownBy, Object jsonDoc) {
         // generate canvases in a same order as the web resources
         List<WebResource> sortedResources = EdmManifestUtils.getSortedWebResources(europeanaId, isShownBy, jsonDoc);
         if (sortedResources.isEmpty()) {
@@ -257,13 +258,14 @@ public final class EdmManifestMappingV2 {
         Map<String, Object>[] services = JsonPath.parse(jsonDoc).read("$.object[?(@.services)].services[*]", Map[].class);
         List<eu.europeana.iiif.model.v2.Canvas> canvases = new ArrayList<>(sortedResources.size());
         for (WebResource webResource: sortedResources) {
-            canvases.add(getCanvasV2(europeanaId, order, webResource, services, jsonDoc));
+            canvases.add(getCanvasV2(settings, europeanaId, order, webResource, services, jsonDoc));
             order++;
         }
         // there should be only 1 sequence, so sequence number is always 1
         eu.europeana.iiif.model.v2.Sequence[] result = new eu.europeana.iiif.model.v2.Sequence[1];
         result[0] = new eu.europeana.iiif.model.v2.Sequence();
-        result[0].setStartCanvas(ManifestDefinitions.getCanvasId(europeanaId, 1));
+//        result[0].setStartCanvas(ManifestDefinitions.getCanvasId(europeanaId, 1));
+        result[0].setStartCanvas(settings.getCanvasId(europeanaId, 1));
         result[0].setCanvases(canvases.toArray(new eu.europeana.iiif.model.v2.Canvas[0]));
         return result;
     }
@@ -310,13 +312,14 @@ public final class EdmManifestMappingV2 {
     /**
      * Generates a new canvas, but note that we do not fill the otherContent (Full-Text) here. That is done later
      */
-    private static eu.europeana.iiif.model.v2.Canvas getCanvasV2(String europeanaId,
+    private static eu.europeana.iiif.model.v2.Canvas getCanvasV2(ManifestSettings settings,
+                                                                 String europeanaId,
                                                                  int order,
                                                                  WebResource webResource,
                                                                  Map<String, Object>[] services,
                                                                  Object jsonDoc) {
         eu.europeana.iiif.model.v2.Canvas c =
-                new eu.europeana.iiif.model.v2.Canvas(ManifestDefinitions.getCanvasId(europeanaId, order), order);
+                new eu.europeana.iiif.model.v2.Canvas(settings.getCanvasId(europeanaId, order), order);
 
         c.setLabel("p. "+order);
 

--- a/src/main/java/eu/europeana/iiif/service/EdmManifestMappingV3.java
+++ b/src/main/java/eu/europeana/iiif/service/EdmManifestMappingV3.java
@@ -93,7 +93,7 @@ public final class EdmManifestMappingV3 {
         manifest.setThumbnail(getThumbnailImageV3(europeanaId, jsonDoc));
         manifest.setNavDate(EdmManifestUtils.getNavDate(europeanaId, jsonDoc));
         manifest.setHomePage(EdmManifestUtils.getHomePage(europeanaId, jsonDoc));
-        manifest.setRequiredStatement(getAttributionV3(europeanaId, isShownBy, jsonDoc));
+        manifest.setRequiredStatement(getAttributionV3Root(europeanaId, isShownBy, jsonDoc));
         manifest.setRights(getRights(europeanaId, jsonDoc));
         manifest.setSeeAlso(getDataSetsV3(europeanaId));
         manifest.setItems(getItems(europeanaId, isShownBy, jsonDoc, euScreenTypeHack));
@@ -314,18 +314,21 @@ public final class EdmManifestMappingV3 {
      * @param jsonDoc parsed json document
      * @return
      */
-    static RequiredStatementMap getAttributionV3(String europeanaId, String isShownBy, Object jsonDoc) {
+    static RequiredStatementMap getAttributionV3Root(String europeanaId, String isShownBy, Object jsonDoc) {
         Filter isShownByFilter = filter(where(EdmManifestUtils.ABOUT).is(isShownBy));
         String[] attributions = JsonPath.parse(jsonDoc).
                 read("$.object.aggregations[*].webResources[?]."+ EdmManifestUtils.HTML_ATTRIB_SNIPPET, String[].class, isShownByFilter);
         String attribution = (String) EdmManifestUtils.getFirstValueArray(EdmManifestUtils.HTML_ATTRIB_SNIPPET, europeanaId, attributions);
+        return createRequiredStatementMap(attribution);
+    }
+
+    static RequiredStatementMap createRequiredStatementMap(String attribution){
         if (StringUtils.isEmpty(attribution)) {
             return null;
         }
         return new RequiredStatementMap(new LanguageMap(LanguageMap.DEFAULT_METADATA_KEY, ATTRIBUTION_STRING),
                                         new LanguageMap(LanguageMap.DEFAULT_METADATA_KEY, attribution));
     }
-
 
     /**
      * Generates 3 datasets with the appropriate ID and format (one for rdf/xml, one for json and one for json-ld)
@@ -426,7 +429,7 @@ public final class EdmManifestMappingV3 {
 
         String attributionText = (String) webResource.get(EdmManifestUtils.HTML_ATTRIB_SNIPPET);
         if (!StringUtils.isEmpty(attributionText)){
-            c.setRequiredStatement(new LanguageMap(LanguageMap.DEFAULT_METADATA_KEY, attributionText));
+            c.setRequiredStatement(createRequiredStatementMap(attributionText));
         }
 
         LinkedHashMap<String, ArrayList<String>> license = (LinkedHashMap<String, ArrayList<String>>) webResource.get("webResourceEdmRights");

--- a/src/main/java/eu/europeana/iiif/service/EdmManifestUtils.java
+++ b/src/main/java/eu/europeana/iiif/service/EdmManifestUtils.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static eu.europeana.iiif.model.ManifestDefinitions.getFulltextSearchPath;
-
 /**
  * This class contains all the common methods for mapping EDM record data to IIIF Manifest data for IIIF v2 and v3
  *
@@ -225,9 +223,9 @@ public final class EdmManifestUtils {
      *
      * @param europeanaId identifier to include in the path
      */
-    public static String getFullTextSearchUrl(String fulltextBaseUrl, String europeanaId) {
-        return fulltextBaseUrl + getFulltextSearchPath(europeanaId);
-    }
+//    public static String getFullTextSearchUrl(String fulltextBaseUrl, String europeanaId) {
+//        return fulltextBaseUrl + getFulltextSearchPath(europeanaId);
+//    }
 
     /**
      * Returns the data provider Aggregation

--- a/src/main/java/eu/europeana/iiif/service/ManifestService.java
+++ b/src/main/java/eu/europeana/iiif/service/ManifestService.java
@@ -381,6 +381,8 @@ public class ManifestService {
      * @return
      */
     private Map<String, FulltextSummaryCanvas> createSummaryCanvasMap(FulltextSummary summary) {
+        // TODO discuss with Hugo how to handle this issue of the granularity only making sense on the SummaryCanvas level
+        String[] textGranularity = summary.getTextGranularity();
         LinkedHashMap<String, FulltextSummaryCanvas> summaryCanvasMap = new LinkedHashMap<>();
         for (FulltextSummaryCanvas fulltextSummaryCanvas : summary.getCanvases()) {
             FulltextSummaryCanvas canvas = summaryCanvasMap.get(fulltextSummaryCanvas.getPageNumber());

--- a/src/main/java/eu/europeana/iiif/service/ManifestService.java
+++ b/src/main/java/eu/europeana/iiif/service/ManifestService.java
@@ -308,8 +308,6 @@ public class ManifestService {
         }
     }
 
-
-
     /**
      * Performs a GET request for a particular EuropeanaID that:
      * - lists all canvases found for that EuropeanaID;

--- a/src/main/resources/iiif.properties
+++ b/src/main/resources/iiif.properties
@@ -1,15 +1,34 @@
 # IIIF settings
 
-# location from where record data is retrieved
+# MANIFEST_API_ENDPOINT
+manifest-api.baseurl = https://iiif.europeana.eu
+manifest-api.path = /presentation/<DATASET_ID>/<RECORD_ID>
+
+# CONTENT_SEARCH_API_ENDPOINT
+content-search-api.baseurl = https://iiif.europeana.eu
+content-search-api.path    = /record/v2
+
+# FULLTEXT_API_ENDPOINT location where we check if full text pages are available or not
+fulltext-api.baseurl = https://iiif.europeana.eu
+fulltext-api.path    = /presentation/<collectionId>/<itemId>/annopage/<pageId>
+
+# RECORD_API_ENDPOINT location from where record data is retrieved
 record-api.baseurl   = https://api.europeana.eu
 record-api.path      = /record/v2
 
-# location where we check if full text pages are available or not
-fulltext-api.baseurl = https://iiif.europeana.eu
-
-# Thumbnail API baseURL
+# THUMBNAIL_API_ENDPOINT Thumbnail API baseURL
 thumbnail-api.baseurl = https://api.europeana.eu
 thumbnail-api.path    = /thumbnail/v2/url.json?uri=
+
+# ANNOTATION_DATA_ENDPOINT
+annotation-data.baseurl = http://data.europeana.eu
+annotation-data.path
+
+# FULLTEXT_DATA_ENDPOINT
+fulltext-data.baseurl = http://data.europeana.eu
+fulltext-data.path
+
+
 
 # For production we suppress json parse exceptions, but for testing we want to see those exceptions
 suppress-parse-exception = true
@@ -17,3 +36,4 @@ suppress-parse-exception = true
 #actuator
 management.endpoints.web.base-path=/actuator
 management.endpoints.web.exposure.include=info
+

--- a/src/main/resources/iiif.properties
+++ b/src/main/resources/iiif.properties
@@ -19,15 +19,6 @@ record-api.path      = /record/v2
 thumbnail-api.baseurl = https://api.europeana.eu
 thumbnail-api.path    = /thumbnail/v2/url.json?uri=
 
-# ANNOTATION_DATA_ENDPOINT (not used in manifest API)
-annotation-data.baseurl = http://data.europeana.eu
-annotation-data.path
-
-# FULLTEXT_DATA_ENDPOINT (not used in manifest API)
-fulltext-data.baseurl = http://data.europeana.eu
-fulltext-data.path
-
-
 
 # For production we suppress json parse exceptions, but for testing we want to see those exceptions
 suppress-parse-exception = true

--- a/src/main/resources/iiif.properties
+++ b/src/main/resources/iiif.properties
@@ -9,8 +9,7 @@ manifest-api.id.placeholder = /<DATASET_ID>/<RECORD_ID>
 content-search-api.baseurl = https://iiif.europeana.eu
 
 # FULLTEXT_API_ENDPOINT location where we check if full text pages are available or not
-#fulltext-api.baseurl = https://iiif.europeana.eu
-fulltext-api.baseurl = http://localhost
+fulltext-api.baseurl = https://iiif.europeana.eu
 
 # RECORD_API_ENDPOINT location from where record data is retrieved
 record-api.baseurl   = https://api.europeana.eu

--- a/src/main/resources/iiif.properties
+++ b/src/main/resources/iiif.properties
@@ -7,11 +7,9 @@ manifest-api.id.placeholder = /<DATASET_ID>/<RECORD_ID>
 
 # CONTENT_SEARCH_API_ENDPOINT
 content-search-api.baseurl = https://iiif.europeana.eu
-content-search-api.path    = /record/v2
 
 # FULLTEXT_API_ENDPOINT location where we check if full text pages are available or not
 fulltext-api.baseurl = https://iiif.europeana.eu
-fulltext-api.path    = /presentation/<collectionId>/<itemId>/annopage/<pageId>
 
 # RECORD_API_ENDPOINT location from where record data is retrieved
 record-api.baseurl   = https://api.europeana.eu

--- a/src/main/resources/iiif.properties
+++ b/src/main/resources/iiif.properties
@@ -9,7 +9,8 @@ manifest-api.id.placeholder = /<DATASET_ID>/<RECORD_ID>
 content-search-api.baseurl = https://iiif.europeana.eu
 
 # FULLTEXT_API_ENDPOINT location where we check if full text pages are available or not
-fulltext-api.baseurl = https://iiif.europeana.eu
+#fulltext-api.baseurl = https://iiif.europeana.eu
+fulltext-api.baseurl = http://localhost
 
 # RECORD_API_ENDPOINT location from where record data is retrieved
 record-api.baseurl   = https://api.europeana.eu

--- a/src/main/resources/iiif.properties
+++ b/src/main/resources/iiif.properties
@@ -2,7 +2,8 @@
 
 # MANIFEST_API_ENDPOINT
 manifest-api.baseurl = https://iiif.europeana.eu
-manifest-api.path = /presentation/<DATASET_ID>/<RECORD_ID>
+manifest-api.presentation.path = /presentation
+manifest-api.id.placeholder = /<DATASET_ID>/<RECORD_ID>
 
 # CONTENT_SEARCH_API_ENDPOINT
 content-search-api.baseurl = https://iiif.europeana.eu
@@ -20,11 +21,11 @@ record-api.path      = /record/v2
 thumbnail-api.baseurl = https://api.europeana.eu
 thumbnail-api.path    = /thumbnail/v2/url.json?uri=
 
-# ANNOTATION_DATA_ENDPOINT
+# ANNOTATION_DATA_ENDPOINT (not used in manifest API)
 annotation-data.baseurl = http://data.europeana.eu
 annotation-data.path
 
-# FULLTEXT_DATA_ENDPOINT
+# FULLTEXT_DATA_ENDPOINT (not used in manifest API)
 fulltext-data.baseurl = http://data.europeana.eu
 fulltext-data.path
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,11 +2,10 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <!-- For use with k8s -->
+            <!-- Use this pattern for Kubernetes deployments -->
             <PatternLayout pattern="%d{HH:mm:ss.SSS} %level %C:%L [%t] - %m%n" />
-            <!-- Use the JSON layout for production (logging to ELK) -->
-            <!-- <PatternLayout pattern="{&quot;@timestamp&quot;:&quot;%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}&quot;,&quot;level&quot;:&quot;%-5p&quot;,&quot;thread&quot;:&quot;%t&quot;,&quot;class&quot;:&quot;%C&quot;, &quot;code_line_number&quot;:&quot;%L&quot;,&quot;message&quot;:&quot;%m&quot;}%n" />-->
-            <!-- Use this pattern for local debugging -->
+           
+            <!-- Optional pattern with color encoding for local debugging -->
             <!-- <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %highlight{%level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=blue} %logger{36} - %msg%n" /> -->
         </Console>
     </Appenders>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,9 +2,10 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
+            <!-- For use with k8s -->
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %level %C:%L [%t] - %m%n" />
             <!-- Use the JSON layout for production (logging to ELK) -->
-            <PatternLayout pattern="{&quot;@timestamp&quot;:&quot;%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}&quot;,&quot;level&quot;:&quot;%-5p&quot;,&quot;thread&quot;:&quot;%t&quot;,&quot;class&quot;:&quot;%C&quot;, &quot;code_line_number&quot;:&quot;%L&quot;,&quot;message&quot;:&quot;%m&quot;}%n" />
-
+            <!-- <PatternLayout pattern="{&quot;@timestamp&quot;:&quot;%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}&quot;,&quot;level&quot;:&quot;%-5p&quot;,&quot;thread&quot;:&quot;%t&quot;,&quot;class&quot;:&quot;%C&quot;, &quot;code_line_number&quot;:&quot;%L&quot;,&quot;message&quot;:&quot;%m&quot;}%n" />-->
             <!-- Use this pattern for local debugging -->
             <!-- <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %highlight{%level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=blue} %logger{36} - %msg%n" /> -->
         </Console>

--- a/src/test/java/eu/europeana/iiif/model/info/FulltextSummaryManifestCanvasTest.java
+++ b/src/test/java/eu/europeana/iiif/model/info/FulltextSummaryManifestCanvasTest.java
@@ -4,7 +4,7 @@ package eu.europeana.iiif.model.info;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class FulltextSummaryCanvasTest {
+public class FulltextSummaryManifestCanvasTest {
 
     @Test
     public void testPageId() {

--- a/src/test/java/eu/europeana/iiif/service/EdmManifestV2MappingTest.java
+++ b/src/test/java/eu/europeana/iiif/service/EdmManifestV2MappingTest.java
@@ -6,6 +6,7 @@ import eu.europeana.iiif.model.v2.*;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
@@ -21,11 +22,14 @@ import static org.junit.Assert.*;
  */
 
 @TestPropertySource("classpath:iiif-test.properties")
-@SpringBootTest(classes = {EdmManifestMappingV2.class})
+@SpringBootTest(classes = {EdmManifestMappingV2.class, ManifestSettings.class})
 public class EdmManifestV2MappingTest {
 
     // Initialize the manifest service, because that will setup our default Jackson mapper configuration used in the tests
     private static final ManifestService ms = new ManifestService(new ManifestSettings());
+
+    @Autowired
+    private ManifestSettings settings;
 
     @Test
     public void testId() {
@@ -249,7 +253,7 @@ public class EdmManifestV2MappingTest {
      */
     @Test
     public void testSeeAlso() {
-        DataSet[] datasets = EdmManifestMappingV2.getDataSetsV2("TEST-ID");
+        DataSet[] datasets = EdmManifestMappingV2.getDataSetsV2(settings, "TEST-ID");
         Assertions.assertNotNull(datasets);
         Assertions.assertEquals(3, datasets.length);
         for (DataSet dataset : datasets) {
@@ -263,7 +267,7 @@ public class EdmManifestV2MappingTest {
     @Test
     public void testSequenceEmpty() {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_EMPTY);
-        Assertions.assertNull(EdmManifestMappingV2.getSequencesV2("test", null, document));
+        Assertions.assertNull(EdmManifestMappingV2.getSequencesV2(settings, "test", null, document));
     }
 
     /**
@@ -272,7 +276,7 @@ public class EdmManifestV2MappingTest {
     @Test
     public void testSequenceMissingIsShownAtHasView() {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_SEQUENCE_2CANVAS_NOISSHOWNBY);
-        Assertions.assertNull(EdmManifestMappingV2.getSequencesV2("test", null, document));
+        Assertions.assertNull(EdmManifestMappingV2.getSequencesV2(settings, "test", null, document));
     }
 
     /**
@@ -282,7 +286,7 @@ public class EdmManifestV2MappingTest {
     public void testSequence() {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_SEQUENCE_3CANVAS_1SERVICE);
         String edmIsShownBy = EdmManifestUtils.getValueFromDataProviderAggregation(document, null, "edmIsShownBy");
-        Sequence[] sequence = EdmManifestMappingV2.getSequencesV2("/test-id", edmIsShownBy, document);
+        Sequence[] sequence = EdmManifestMappingV2.getSequencesV2(settings, "/test-id", edmIsShownBy, document);
         Assertions.assertNotNull(sequence);
         Assertions.assertEquals(1, sequence.length); // there should always be only 1 sequence
 

--- a/src/test/java/eu/europeana/iiif/service/EdmManifestV3MappingTest.java
+++ b/src/test/java/eu/europeana/iiif/service/EdmManifestV3MappingTest.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
@@ -20,13 +21,16 @@ import org.springframework.test.context.TestPropertySource;
  */
 
 @TestPropertySource("classpath:iiif-test.properties")
-@SpringBootTest(classes = {EdmManifestMappingV3.class})
+@SpringBootTest(classes = {EdmManifestMappingV3.class, ManifestSettings.class})
 public class EdmManifestV3MappingTest {
 
     private static final Logger LOG = LogManager.getLogger(EdmManifestV3MappingTest.class);
 
     // Initialize the manifest service, because that will setup our default Jackson mapper configuration used in the tests
     private static final ManifestService ms = new ManifestService(new ManifestSettings());
+
+    @Autowired
+    private ManifestSettings settings;
 
     // we don't test some fields because this is already done in v2, for example 'id' and 'navdate'
 
@@ -265,7 +269,7 @@ public class EdmManifestV3MappingTest {
      */
     @Test
     public void testSeeAlso() {
-        DataSet[] datasets = EdmManifestMappingV3.getDataSetsV3("TEST-ID");
+        DataSet[] datasets = EdmManifestMappingV3.getDataSetsV3(settings, "TEST-ID");
         Assertions.assertNotNull(datasets);
         Assertions.assertEquals(3, datasets.length);
         for (DataSet dataset : datasets) {
@@ -280,7 +284,7 @@ public class EdmManifestV3MappingTest {
     public void testStartCanvas() {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_SEQUENCE_3CANVAS_1SERVICE);
         String edmIsShownBy = EdmManifestUtils.getValueFromDataProviderAggregation(document, null, "edmIsShownBy");
-        Canvas[] canvases = EdmManifestMappingV3.getItems("/test-id", edmIsShownBy, document, null);
+        Canvas[] canvases = EdmManifestMappingV3.getItems(settings, "/test-id", edmIsShownBy, document, null);
         Canvas start = EdmManifestMappingV3.getStartCanvasV3(canvases, edmIsShownBy);
 
         // test if only a few fields are set and the rest is null
@@ -305,7 +309,7 @@ public class EdmManifestV3MappingTest {
         Assertions.assertNotNull(edmIsShownBy);
         Assertions.assertNull(isShownAt);
 
-        Canvas[] canvases = EdmManifestMappingV3.getItems("/test-id", edmIsShownBy, document, null);
+        Canvas[] canvases = EdmManifestMappingV3.getItems(settings, "/test-id", edmIsShownBy, document, null);
         Canvas start = EdmManifestMappingV3.getStartCanvasV3(canvases, edmIsShownBy);
 
         ExpectedCanvasAndAnnotationPageValues expectedCanvas = new ExpectedCanvasAndAnnotationPageValues();
@@ -319,7 +323,7 @@ public class EdmManifestV3MappingTest {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_SEQUENCE_3CANVAS_NOISSHOWNBY);
         String edmIsShownBy = EdmManifestUtils.getValueFromDataProviderAggregation(document, null, "edmIsShownBy");
 
-        Canvas[] canvases = EdmManifestMappingV3.getItems("/test-id", edmIsShownBy, document, null);
+        Canvas[] canvases = EdmManifestMappingV3.getItems(settings, "/test-id", edmIsShownBy, document, null);
         Canvas start = EdmManifestMappingV3.getStartCanvasV3(canvases, edmIsShownBy);
 
         // test if only a few fields are set and the rest is null
@@ -340,7 +344,7 @@ public class EdmManifestV3MappingTest {
     @Test
     public void testCanvasEmpty() {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_EMPTY);
-        Assertions.assertNull(EdmManifestMappingV3.getItems("test", null, document, null));
+        Assertions.assertNull(EdmManifestMappingV3.getItems(settings, "test", null, document, null));
     }
 
     /**
@@ -349,7 +353,7 @@ public class EdmManifestV3MappingTest {
     @Test
     public void testCanvasMissingIsShownAtHasView() {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_SEQUENCE_2CANVAS_NOISSHOWNBY);
-        Assertions.assertNull(EdmManifestMappingV3.getItems("test", null, document, null));
+        Assertions.assertNull(EdmManifestMappingV3.getItems(settings, "test", null, document, null));
     }
 
     /**
@@ -359,7 +363,7 @@ public class EdmManifestV3MappingTest {
     public void testCanvases() {
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(EdmManifestData.TEST_SEQUENCE_3CANVAS_1SERVICE);
         String edmIsShownBy = EdmManifestUtils.getValueFromDataProviderAggregation(document, null, "edmIsShownBy");
-        Canvas[] canvases = EdmManifestMappingV3.getItems("/test-id", edmIsShownBy, document, null);
+        Canvas[] canvases = EdmManifestMappingV3.getItems(settings, "/test-id", edmIsShownBy, document, null);
         Assertions.assertNotNull(canvases);
         // note that the 3rd canvas is not edmIsShownBy or hasView so not included
         Assertions.assertEquals(2, canvases.length);


### PR DESCRIPTION
### PLEASE NOTE

This PR is built on top of the changes of [PR #58](https://github.com/europeana/iiif-manifest-api/pull/58) and contains all changes for EA-3325 and EA-3369.
**It is therefore easiest to review the changes for EA-3325 and EA-3369 together using this PR, merge this PR to Master and discard PR [PR #58](https://github.com/europeana/iiif-manifest-api/pull/58).**
If you want to do them separately, **make sure to merge [PR #58](https://github.com/europeana/iiif-manifest-api/pull/58) first.** 

In both cases, some manual merges need to be applied. Let me know if you need any clarification.. 

Both tickets contain some refactoring: EA-3325 contains more extensive refactoring of the iiif-properties (related to added base URLs), and EA-3369 has some changes in the naming of the Fulltext Summary classes, in order to align them with how they are named in the FT Api (most importantly, FulltextSummary => FulltextSummaryAnnoPage).